### PR TITLE
Use HTML template for directory listing.

### DIFF
--- a/server/dirlist.go
+++ b/server/dirlist.go
@@ -1,6 +1,6 @@
 package server
 
-import "text/template"
+import "html/template"
 import "fmt"
 import "os"
 import "time"
@@ -147,7 +147,6 @@ func (this *RanServer) listDir(w http.ResponseWriter, serveAll bool, c *context)
         if i.IsDir() {
             name += "/"
         }
-        name = html.EscapeString(name)
 
         // skip hidden path
         if !serveAll && strings.HasPrefix(name, ".") {


### PR DESCRIPTION
Manually espcaping filenames was causing bad paths when the files
contained an escaped character. By switching to `html/template`, we can
use the automatic escaping which is context appropriate.