### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/server/error.go
+++ b/server/error.go
@@ -7,7 +7,7 @@ import "path"
 import hhelper "github.com/m3ng9i/go-utils/http"
 
 
-// Write http error, accrording status code and msg, return number of bytes write to ResponseWriter.
+// ErrorEx writes http error, accrording status code and msg, return number of bytes write to ResponseWriter.
 // Parameter msg is a string contains html, could be ignored.
 func ErrorEx(w http.ResponseWriter, code int, title, msg string) int64 {
     status := http.StatusText(code)
@@ -40,7 +40,7 @@ func Error(w http.ResponseWriter, code int) int64 {
 }
 
 
-// Write 404 file to client.
+// ErrorFile404 writes 404 file to client.
 // abspath is path of 404 file.
 func ErrorFile404(w http.ResponseWriter, abspath string) (int64, error) {
 

--- a/server/log_handler.go
+++ b/server/log_handler.go
@@ -56,7 +56,7 @@ var LogLayoutShort LogLayout = `Access #%i: [%s] [%h] [%a] [%m] [%S] [%l] [%r] [
 var LogLayoutMin LogLayout = `Access #%i: [%s] [%a] [%m] [%l] [%n]`
 
 
-// Check if a log layout is legal.
+// IsLegal checks if a log layout is legal.
 func (this *LogLayout) IsLegal() bool {
 
     var in bool


### PR DESCRIPTION
Hi, I've changed these public function comments to comply with [this standard](https://golang.org/doc/effective_go.html#commentary) in Effective Go. It's admittedly a small fix but I hope it helps!